### PR TITLE
Add support for rails >= 5.1

### DIFF
--- a/lib/wiselinks/controller_methods.rb
+++ b/lib/wiselinks/controller_methods.rb
@@ -8,7 +8,7 @@ module Wiselinks
       base.helper_method :wiselinks_robots
       base.helper_method :wiselinks_link_rel_prev
       base.helper_method :wiselinks_link_rel_next
-      base.before_filter :set_wiselinks_url
+      base.before_action :set_wiselinks_url
     end
 
   protected

--- a/lib/wiselinks/rendering.rb
+++ b/lib/wiselinks/rendering.rb
@@ -2,7 +2,8 @@ module Wiselinks
   module Rendering
 
     def self.included(base)
-      base.alias_method_chain :render, :wiselinks
+      base.alias_method :render_without_wiselinks, :render
+      base.alias_method :render, :render_with_wiselinks
     end
 
   protected

--- a/lib/wiselinks/request.rb
+++ b/lib/wiselinks/request.rb
@@ -1,8 +1,11 @@
 module Wiselinks
   module Request
     def self.included(base)
-      base.alias_method_chain :referer, :wiselinks
-      base.alias_method_chain :referrer, :wiselinks
+      base.alias_method :referer_without_wiselinks, :referer
+      base.alias_method :referer, :referer_with_wiselinks
+
+      base.alias_method :referrer_without_wiselinks, :referrer
+      base.alias_method :referrer, :referrer_with_wiselinks
     end
 
     def referer_with_wiselinks

--- a/wiselinks.gemspec
+++ b/wiselinks.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'sqlite3'
-  gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'factory_girl'
   gem.add_development_dependency 'faker'


### PR DESCRIPTION
- remove calls to `alias_method_chain`, manually chaining methods
- replace `before_filter` with `before_action`